### PR TITLE
Simplify lock expiration mechanism and add ownership safety to release()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,12 @@
 		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
-			<version>1.5.2</version>
+			<version>2.6.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.2</version>
+			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -69,7 +69,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.2</version>
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>
@@ -81,7 +81,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.8</version>
+				<version>2.10.1</version>
 				<configuration>
 					<minmemory>128m</minmemory>
 					<maxmemory>256m</maxmemory>
@@ -98,7 +98,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.1.2</version>
+				<version>2.4</version>
 				<executions>
 					<execution>
 						<id>attach-source</id>
@@ -111,7 +111,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.2</version>
+				<version>1.5</version>
 				<configuration>
 				    <keyname>alois.belaska@gmail.com</keyname>
 				</configuration>

--- a/src/main/java/com/github/jedis/lock/JedisLock.java
+++ b/src/main/java/com/github/jedis/lock/JedisLock.java
@@ -17,12 +17,12 @@ public class JedisLock {
 	String lockKey;
 
 	/**
-	 * Lock expiration in miliseconds.
+	 * Lock expiration in milliseconds.
 	 */
 	int expireMsecs = 60 * 1000;
 
 	/**
-	 * Acquire timeout in miliseconds.
+	 * Acquire timeout in milliseconds.
 	 */
 	int timeoutMsecs = 10 * 1000;
 
@@ -46,8 +46,8 @@ public class JedisLock {
 	 * @param jedis
 	 * @param lockKey
 	 *            lock key (ex. account:1, ...)
-	 * @param timeoutSecs
-	 *            acquire timeout in miliseconds (default: 10000 msecs)
+	 * @param timeoutMsecs
+	 *            acquire timeout in milliseconds (default: 10000 msecs)
 	 */
 	public JedisLock(Jedis jedis, String lockKey, int timeoutMsecs) {
 		this(jedis, lockKey);
@@ -60,10 +60,10 @@ public class JedisLock {
 	 * @param jedis
 	 * @param lockKey
 	 *            lock key (ex. account:1, ...)
-	 * @param timeoutSecs
-	 *            acquire timeout in miliseconds (default: 10000 msecs)
+	 * @param timeoutMsecs
+	 *            acquire timeout in milliseconds (default: 10000 msecs)
 	 * @param expireMsecs
-	 *            lock expiration in miliseconds (default: 60000 msecs)
+	 *            lock expiration in milliseconds (default: 60000 msecs)
 	 */
 	public JedisLock(Jedis jedis, String lockKey, int timeoutMsecs, int expireMsecs) {
 		this(jedis, lockKey, timeoutMsecs);
@@ -85,7 +85,7 @@ public class JedisLock {
 	 * 
 	 * @param lockKey
 	 *            lock key (ex. account:1, ...)
-	 * @param timeoutSecs
+	 * @param timeoutMsecs
 	 *            acquire timeout in miliseconds (default: 10000 msecs)
 	 */
 	public JedisLock(String lockKey, int timeoutMsecs) {
@@ -97,7 +97,7 @@ public class JedisLock {
 	 * 
 	 * @param lockKey
 	 *            lock key (ex. account:1, ...)
-	 * @param timeoutSecs
+	 * @param timeoutMsecs
 	 *            acquire timeout in miliseconds (default: 10000 msecs)
 	 * @param expireMsecs
 	 *            lock expiration in miliseconds (default: 60000 msecs)
@@ -116,7 +116,6 @@ public class JedisLock {
 	/**
 	 * Acquire lock.
 	 * 
-	 * @param jedis
 	 * @return true if lock is acquired, false acquire timeouted
 	 * @throws InterruptedException
 	 *             in case of thread interruption
@@ -129,7 +128,7 @@ public class JedisLock {
 	 * Acquire lock.
 	 * 
 	 * @param jedis
-	 * @return true if lock is acquired, false acquire timeouted
+	 * @return true if lock is acquired, false acquire timed out
 	 * @throws InterruptedException
 	 *             in case of thread interruption
 	 */
@@ -165,14 +164,14 @@ public class JedisLock {
 	}
 
 	/**
-	 * Acqurired lock release.
+	 * Acquired lock release.
 	 */
 	public synchronized void release() {
 		release(jedis);
 	}
 
 	/**
-	 * Acqurired lock release.
+	 * Acquired lock release.
 	 */
 	public synchronized void release(Jedis jedis) {
 		if (locked) {

--- a/src/main/java/com/github/jedis/lock/JedisLock.java
+++ b/src/main/java/com/github/jedis/lock/JedisLock.java
@@ -9,24 +9,24 @@ import redis.clients.jedis.Jedis;
  */
 public class JedisLock {
 
-	Jedis jedis;
+	private Jedis jedis;
 
 	/**
 	 * Lock key path.
 	 */
-	String lockKey;
+	private String lockKey;
 
 	/**
 	 * Lock expiration in milliseconds.
 	 */
-	int expireMsecs = 60 * 1000;
+	private int expireMsecs = 60 * 1000;
 
 	/**
 	 * Acquire timeout in milliseconds.
 	 */
-	int timeoutMsecs = 10 * 1000;
+	private int timeoutMsecs = 10 * 1000;
 
-	boolean locked = false;
+	private boolean locked = false;
 
 	/**
 	 * Detailed constructor with default acquire timeout 10000 msecs and lock expiration of 60000 msecs.


### PR DESCRIPTION
cc @abelaska 

Reviving this project from 4 years of dormancy :) Some notes: 

Simplifying the lock expiration mechanism:

Since Redis 2.6.12, the SET operation supports a set of options which
modify its behavior (see: http://redis.io/commands/set). The options
we are interested in are PX (set specified expire time in ms) and NX
(only set the key if it does not already exist).

The ability to perform both of these atomically is awesome for our use
case. Replacing the former call to SETNX with the new SET with options
not only moves us away from using deprecated functionality but also
allows us to drop the expiration checking code of past.

Adding lock ownership for safety:

To prevent locks from releasing each others hold on keys, we introduce a
unique token. The token is the value of the lockKey. In release(), a
check was added which (atomically, with the Lua script) releases the
lock only if the lock owner releases.

Unfortunately, I don't believe there is any way to achieve this behavior
with Redis without the aid of a Lua script.
